### PR TITLE
Fix bug with several endpoints not including app_id

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -322,6 +322,9 @@ Client.prototype.newSession = function (playerId, body, callback) {
   if (!this.app) {
     throw 'You must define an "app" object.'
   }
+  if (!('app_id' in body)) {
+    body.app_id = this.app.appId;
+  }
   var requestUri = this.API_URI + constants.DEVICES_PATH + '/' + playerId + '/on_session';
   return basicRequest(requestUri, this.app.appAuthKey, 'POST', body, callback);
 };
@@ -337,6 +340,9 @@ Client.prototype.newPurchase = function (playerId, body, callback) {
   if (!this.app) {
     throw 'You must define an "app" object.'
   }
+  if (!('app_id' in body)) {
+    body.app_id = this.app.appId;
+  }
   var requestUri = this.API_URI + constants.DEVICES_PATH + '/' + playerId + '/on_purchase';
   return basicRequest(requestUri, this.app.appAuthKey, 'POST', body, callback);
 };
@@ -351,6 +357,9 @@ Client.prototype.newPurchase = function (playerId, body, callback) {
 Client.prototype.incrementSessionLength = function (playerId, body, callback) {
   if (!this.app) {
     throw 'You must define an "app" object.'
+  }
+  if (!('app_id' in body)) {
+    body.app_id = this.app.appId;
   }
   var requestUri = this.API_URI + constants.DEVICES_PATH + '/' + playerId + '/on_focus';
   return basicRequest(requestUri, this.app.appAuthKey, 'POST', body, callback);

--- a/lib/client.js
+++ b/lib/client.js
@@ -276,6 +276,9 @@ Client.prototype.editDevice = function (deviceId, body, callback) {
   if (!this.app) {
     throw 'You must define an "app" object.'
   }
+  if (!('app_id' in body)) {
+    body.app_id = this.app.appId;
+  }
   return basicRequest(this.API_URI + constants.DEVICES_PATH + '/' + deviceId, this.app.appAuthKey, 'PUT', body, callback);
 };
 


### PR DESCRIPTION
The OneSignal API requires passing `app_id` in device update calls. Edit device calls _without_ `app_id` are deprecated and will stop working in the future.

At your earliest convenience, please publish a patch release with this change.