### PR TITLE
[feat] implements thrown error for appId and apiKey missing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -38,6 +38,9 @@ export class Client {
   public options: Options;
 
   constructor(appId: string, apiKey: string, options?: ClientOptions) {
+    if (appId.length <= 0 && apiKey.length <= 0) {
+      throw new Error('Cannot initialize OneSignal Client please verify your app id and key.');
+    }
     this.appId = appId;
     this.apiKey = apiKey;
 


### PR DESCRIPTION
In line with the fail fast philosophy, this PR causes one signal to fail if the apiKey or appId is empty. This is useful for use cases where env vars are being pulled from a config service that might result in empty string if they are not declared. 