### PR TITLE
Allow boolean and numeric values for tags

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,8 @@ interface KeyAnyObject {
   [key: string]: any;
 }
 
-interface KeyStringObject {
-  [key: string]: string;
+interface TagObject {
+  [key: string]: boolean | number | string;
 }
 
 export interface CreateNotificationBody {
@@ -175,7 +175,7 @@ interface BaseDeviceBody {
   ad_id?: string;
   sdk?: string;
   session_count?: number;
-  tags?: KeyStringObject;
+  tags?: TagObject;
   amount_spent?: string;
   created_at?: number;
   playtime?: number;


### PR DESCRIPTION
Fixes #51

Jon at OneSignal confirmed to me that both booleans and numbers are accepted as tag values. Booleans are converted to strings on the server side, but are explicitly supported in the API (currently only documented in the guides, not the API docs, unfortunately).