### PR TITLE
fix: correct type for CreateNotificationBody.collapse_id

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,7 @@ export interface CreateNotificationBody {
   android_visibility?: number;
   ios_badgeType?: string;
   ios_badgeCount?: number;
-  collapse_id?: number;
+  collapse_id?: string;
   apns_alert?: KeyAnyObject;
 
   // Delivery


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21976938/93550126-c5308e80-f938-11ea-8a26-ace669e5b0ea.png)

As seen in OneSignal's [API docs](https://documentation.onesignal.com/reference/create-notification), `collapse_id` parameter on the `https://onesignal.com/api/v1/notifications` endpoint is a `string`, not a `number`.