### PR TITLE
feat: implements Edit Tags With External User Id server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Please see [this page](https://github.com/zeyneloz/onesignal-node/tree/v2.x) for
   * [View devices](#view-devices)      
   * [View device](#view-device)      
   * [Add a device](#add-a-device)      
-  * [Edit a device](#edit-a-device)      
+  * [Edit a device](#edit-a-device)
+  * [Edit tags with external user id](#edit-tags-with-external-user-id)
   * [New session](#new-session)  
   * [New purchase](#new-purchase)  
   * [Increment Session Length](#increment-session-length)  
@@ -301,7 +302,24 @@ const response = await client.editDevice('device-id',{
 });
 console.log(response.body);
 ```     
-  
+
+### Edit tags with external user id
+   
+https://documentation.onesignal.com/reference/edit-tags-with-external-user-id
+
+```ts
+.editTagsWithExternalUserId(externalUserId: string, body: EditTagsBody): Promise<ClientResponse>
+```  
+ 
+```js      
+const response = await client.editTagsWithExternalUserId('external-user-id', {
+  tags: {
+    customTag: "customValue"
+  },
+});
+console.log(response.body);
+```     
+
 ### New Session     
    
 https://documentation.onesignal.com/reference/new-session

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import {
   NOTIFICATIONS_PATH,
   DEVICES_PATH,
   APPS_PATH,
+  APPS_USERS,
   NOTIFICATIONS_HISTORY,
   DEVICES_ONSESSION,
   DEVICES_ONPURCHASE,
@@ -30,6 +31,7 @@ import {
   IncrementSessionLengthBody,
   ExportCSVBody,
   CreateSegmentBody,
+  EditTagsBody,
 } from './types';
 
 export class Client {
@@ -170,6 +172,22 @@ export class Client {
     // eslint-disable-next-line @typescript-eslint/camelcase
     const postBody = { ...{ [APP_ID_FIELD_NAME]: this.appId }, ...body };
     const uri = `${this.options.apiRoot}/${DEVICES_PATH}/${deviceId}`;
+    return basicAuthRequest(uri, 'PUT', this.apiKey, postBody);
+  }
+
+  /**
+   * Update an existing device's tags in one of your OneSignal apps using the External User ID.
+   * Reference: https://documentation.onesignal.com/reference/edit-tags-with-external-user-id
+   *
+   * @param external_user_id The External User ID.
+   * @param {EditTagsBody} body Request body.
+   *
+   * @return {Promise<ClientResponse>} Http response of One Signal server.
+   */
+  public editTagsWithExternalUserIdDevice(externalUserId: string, body: EditTagsBody): Promise<ClientResponse> {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    const postBody = { ...{ [APP_ID_FIELD_NAME]: this.appId }, ...body };
+    const uri = `${this.options.apiRoot}/${APPS_PATH}/${this.appId}/${APPS_USERS}/${externalUserId}`;
     return basicAuthRequest(uri, 'PUT', this.apiKey, postBody);
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const NOTIFICATIONS_PATH = 'notifications';
 export const NOTIFICATIONS_HISTORY = 'history';
 export const APPS_PATH = 'apps';
 export const APPS_SEGMENTS = 'segments';
+export const APPS_USERS = 'users';
 export const DEVICES_PATH = 'players';
 export const DEVICES_ONSESSION = 'on_session';
 export const DEVICES_ONPURCHASE = 'on_purchase';

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,10 @@ export interface AddDeviceBody extends BaseDeviceBody {
 
 export interface EditDeviceBody extends BaseDeviceBody {}
 
+export interface EditTagsBody {
+  tags: TagObject;
+}
+
 export interface NewSessionBody {
   identifier?: string;
   language?: string;

--- a/test/integration/client.spec.ts
+++ b/test/integration/client.spec.ts
@@ -7,6 +7,7 @@ import * as response from './response';
 import {
   APP1,
   APP1_DEVICE1,
+  APP1_EXTERNAL_USER_ID1,
   APP1_NOTIFICATION1,
   APP1_SEGMENT1,
   MOCKED_API_HOST,
@@ -102,6 +103,14 @@ describe('Test Client for (APP1, MOCKED_API_HOST)', () => {
       const resp = await client.editDevice(APP1_DEVICE1, { ad_id: '1204' });
       expect(resp.statusCode).to.be.equal(response.editDeviceResponse['200OK'].status);
       expect(resp.body).to.be.eql(response.editDeviceResponse['200OK'].response);
+    });
+  });
+
+  describe('(editTagsWithExternalUserId)', () => {
+    it('returns 200 OK and correct response', async () => {
+      const resp = await client.editTagsWithExternalUserIdDevice(APP1_EXTERNAL_USER_ID1, { tags: {customTag: "custom"} });
+      expect(resp.statusCode).to.be.equal(response.editTagsWithExternalUserIdResponse['200OK'].status);
+      expect(resp.body).to.be.eql(response.editTagsWithExternalUserIdResponse['200OK'].response);
     });
   });
 

--- a/test/integration/client.spec.ts
+++ b/test/integration/client.spec.ts
@@ -108,7 +108,9 @@ describe('Test Client for (APP1, MOCKED_API_HOST)', () => {
 
   describe('(editTagsWithExternalUserId)', () => {
     it('returns 200 OK and correct response', async () => {
-      const resp = await client.editTagsWithExternalUserIdDevice(APP1_EXTERNAL_USER_ID1, { tags: {customTag: "custom"} });
+      const resp = await client.editTagsWithExternalUserIdDevice(APP1_EXTERNAL_USER_ID1, {
+        tags: { customTag: 'custom' },
+      });
       expect(resp.statusCode).to.be.equal(response.editTagsWithExternalUserIdResponse['200OK'].status);
       expect(resp.body).to.be.eql(response.editTagsWithExternalUserIdResponse['200OK'].response);
     });

--- a/test/integration/constants.ts
+++ b/test/integration/constants.ts
@@ -6,3 +6,4 @@ export const MOCKED_FAILING_400_API_HOST = 'https://failin-host';
 export const APP1_NOTIFICATION1 = 'app1-notification1-id';
 export const APP1_DEVICE1 = 'app1-device1-id';
 export const APP1_SEGMENT1 = 'app1-segment1-id';
+export const APP1_EXTERNAL_USER_ID1 = 'app1-external_user-id1';

--- a/test/integration/onesignal-mock.ts
+++ b/test/integration/onesignal-mock.ts
@@ -142,7 +142,10 @@ nock(MOCKED_API_HOST, app1NockOptions)
 
 nock(MOCKED_API_HOST, app1NockOptions)
   .put(APP1_EDIT_TAGS_WITH_EXTERNAL_USER_ID_PATH, expectAppIdInBody(APP1.appId))
-  .reply(response.editTagsWithExternalUserIdResponse['200OK'].status, response.editTagsWithExternalUserIdResponse['200OK'].response)
+  .reply(
+    response.editTagsWithExternalUserIdResponse['200OK'].status,
+    response.editTagsWithExternalUserIdResponse['200OK'].response,
+  )
   .persist();
 
 nock(MOCKED_API_HOST, app1NockOptions)

--- a/test/integration/onesignal-mock.ts
+++ b/test/integration/onesignal-mock.ts
@@ -8,6 +8,7 @@ import {
   APP1_DEVICE1,
   APP1_NOTIFICATION1,
   APP1_SEGMENT1,
+  APP1_EXTERNAL_USER_ID1,
   MOCKED_API_HOST,
   MOCKED_FAILING_400_API_HOST,
   USER_AUTH_KEY,
@@ -17,6 +18,7 @@ import {
   APP_ID_QUERY_NAME,
   APPS_PATH,
   APPS_SEGMENTS,
+  APPS_USERS,
   DEVICES_CSVEXPORT,
   DEVICES_ONFOCUS,
   DEVICES_ONPURCHASE,
@@ -36,6 +38,7 @@ const APP1_VIEW_DEVICES_PATH = `/${DEVICES_PATH}`;
 const APP1_VIEW_DEVICE1_PATH = `/${DEVICES_PATH}/${APP1_DEVICE1}`;
 const APP1_ADD_DEVICE_PATH = `/${DEVICES_PATH}`;
 const APP1_EDIT_DEVICE1_PATH = `/${DEVICES_PATH}/${APP1_DEVICE1}`;
+const APP1_EDIT_TAGS_WITH_EXTERNAL_USER_ID_PATH = `/${APPS_PATH}/${APP1.appId}/${APPS_USERS}/${APP1_EXTERNAL_USER_ID1}`;
 const APP1_DELETE_DEVICE1_PATH = `/${DEVICES_PATH}/${APP1_DEVICE1}`;
 const APP1_DEV1_NEW_SESSION_PATH = `/${DEVICES_PATH}/${APP1_DEVICE1}/${DEVICES_ONSESSION}`;
 const APP1_DEV1_NEW_PURCHASE_PATH = `/${DEVICES_PATH}/${APP1_DEVICE1}/${DEVICES_ONPURCHASE}`;
@@ -135,6 +138,11 @@ nock(MOCKED_API_HOST, app1NockOptions)
 nock(MOCKED_API_HOST, app1NockOptions)
   .put(APP1_EDIT_DEVICE1_PATH, expectAppIdInBody(APP1.appId))
   .reply(response.editDeviceResponse['200OK'].status, response.editDeviceResponse['200OK'].response)
+  .persist();
+
+nock(MOCKED_API_HOST, app1NockOptions)
+  .put(APP1_EDIT_TAGS_WITH_EXTERNAL_USER_ID_PATH, expectAppIdInBody(APP1.appId))
+  .reply(response.editTagsWithExternalUserIdResponse['200OK'].status, response.editTagsWithExternalUserIdResponse['200OK'].response)
   .persist();
 
 nock(MOCKED_API_HOST, app1NockOptions)

--- a/test/integration/response.ts
+++ b/test/integration/response.ts
@@ -213,6 +213,13 @@ export const editDeviceResponse = {
   },
 };
 
+export const editTagsWithExternalUserIdResponse = {
+  '200OK': {
+    status: 200,
+    response: { success: true },
+  },
+};
+
 export const deleteDeviceResponse = {
   '200OK': {
     status: 200,

--- a/test/unit/client.spec.ts
+++ b/test/unit/client.spec.ts
@@ -235,7 +235,7 @@ describe('Client', () => {
       const externalUserId = 'external-user-id-1';
       const postBody = {
         tags: {
-          customTag: "1"
+          customTag: '1',
         },
       };
 

--- a/test/unit/client.spec.ts
+++ b/test/unit/client.spec.ts
@@ -16,6 +16,7 @@ import {
   DEVICES_CSVEXPORT,
   APPS_PATH,
   APPS_SEGMENTS,
+  APPS_USERS,
   APP_ID_FIELD_NAME,
   APP_ID_QUERY_NAME,
 } from '../../src/constants';
@@ -226,6 +227,31 @@ describe('Client', () => {
 
       it('makes request with given body', async () => {
         await client.editDevice(deviceId, postBody);
+        expectRequestBodyToHave(requestSpy, postBody);
+      });
+    });
+
+    describe('.editTagsWithExternalUserIdDevice', () => {
+      const externalUserId = 'external-user-id-1';
+      const postBody = {
+        tags: {
+          customTag: "1"
+        },
+      };
+
+      it('makes PUT request with correct path and auth', async () => {
+        await client.editTagsWithExternalUserIdDevice(externalUserId, postBody);
+        const expectedPath = `${API_ROOT}/${APPS_PATH}/${APP_ID}/${APPS_USERS}/${externalUserId}`;
+        expectRequestToBe(requestSpy, expectedPath, 'PUT', APP_API_KEY);
+      });
+
+      it('includes app_id in request body', async () => {
+        await client.editTagsWithExternalUserIdDevice(externalUserId, postBody);
+        expectRequestBodyToHave(requestSpy, { [APP_ID_FIELD_NAME]: APP_ID });
+      });
+
+      it('makes request with given body', async () => {
+        await client.editTagsWithExternalUserIdDevice(externalUserId, postBody);
         expectRequestBodyToHave(requestSpy, postBody);
       });
     });


### PR DESCRIPTION
This PR is intended to add a new feature "Edit Tags With External ID", as referenced at [documentation](https://documentation.onesignal.com/reference/edit-tags-with-external-user-id)