### PR TITLE
pass request options to createNotification

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const userClient = new OneSignal.UserClient('userAuthKey', { apiRoot: 'https://o
 https://documentation.onesignal.com/reference/create-notification 
 
 ```ts
-.createNotification(body: CreateNotificationBody): Promise<ClientResponse>
+.createNotification(body: CreateNotificationBody, customOptions?: ): Promise<ClientResponse>
 ```
 
 Please read the sections above to learn how to create a `Client` object.
@@ -137,9 +137,13 @@ const notification = {
   ]
 };
 
+const customOptions = {
+  timeout: 7000,
+}
+
 // using async/await
 try {
-  const response = await client.createNotification(notification);
+  const response = await client.createNotification(notification, customOptions);
   console.log(response.body.id);
 } catch (e) {
   if (e instanceof OneSignal.HTTPError) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,8 @@ import {
   EditTagsBody,
 } from './types';
 
+import { Options as requestOptions } from 'request';
+
 export class Client {
   public appId: string;
   public apiKey: string;
@@ -54,11 +56,11 @@ export class Client {
    * @param {CreateNotificationBody} body Request body.
    * @returns {Promise<Response>} Http response of One Signal server.
    */
-  public createNotification(body: CreateNotificationBody): Promise<ClientResponse> {
+  public createNotification(body: CreateNotificationBody, customOptions?: Partial<requestOptions>): Promise<ClientResponse> {
     // eslint-disable-next-line @typescript-eslint/camelcase
     const postBody = { ...{ [APP_ID_FIELD_NAME]: this.appId }, ...body };
     const uri = `${this.options.apiRoot}/${NOTIFICATIONS_PATH}`;
-    return basicAuthRequest(uri, 'POST', this.apiKey, postBody);
+    return basicAuthRequest(uri, 'POST', this.apiKey, postBody, customOptions);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,6 +76,7 @@ export const basicAuthRequest = function basicAuthHTTPRequest(
   method: string,
   authKey: string,
   body?: {},
+  customOptions?: Partial<request.Options>,
 ): Promise<request.ResponseAsJSON> {
   const options: request.Options = {
     uri,
@@ -85,6 +86,7 @@ export const basicAuthRequest = function basicAuthHTTPRequest(
       Authorization: `Basic ${authKey}`,
     },
     json: true,
+    ...customOptions,
   };
 
   if (body) {


### PR DESCRIPTION
the create notification gets stuck sometimes, with no error. This pr makes it possible to pass customer options to 'request'. Specifically timeout option.