### PR TITLE
Convert HTTPError.body to string

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,25 @@ export const jsonToQueryString = (obj: { [key: string]: any } = {}): string => {
 };
 
 /**
+ * Return string representation of given object.
+ *
+ * @param inputObj {any} Input object
+ *
+ * @return {string}
+ */
+const anyToString = function convertAnyToString(inputObj: any): string {
+  if (inputObj === undefined) {
+    return 'undefined';
+  }
+
+  if (typeof inputObj === 'string') {
+    return inputObj;
+  }
+
+  return JSON.stringify(inputObj);
+};
+
+/**
  * Make a request using given options and return the response if status code is 2xx.
  * Otherwise, reject with HTTPError.
  *
@@ -53,7 +72,7 @@ const makeRequest = function makeHTTPRequest(options: request.Options): Promise<
 
       // Check if status code is 2xx.
       if (httpResponse.statusCode - 299 > 0) {
-        return reject(new HTTPError(httpResponse.statusCode, httpResponse.body));
+        return reject(new HTTPError(httpResponse.statusCode, anyToString(httpResponse.body)));
       }
 
       return resolve(httpResponse.toJSON());

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -83,16 +83,11 @@ describe('utils', () => {
         id: 0,
       },
     ];
-    const notFoundResponse: [number, {}] = [
-      404,
-      {
-        found: false,
-      },
-    ];
+    const notFoundResponse: [number, string] = [404, 'not found'];
     const internalServerResponse: [number, {}] = [
       500,
       {
-        found: false,
+        error: 'Some internal error',
       },
     ];
 
@@ -169,17 +164,21 @@ describe('utils', () => {
 
     it('rejects with HTTP error when 404 is returned from server', async () => {
       const promise = basicAuthRequest(notFoundRequestUrl, 'GET', authKey);
-      await expect(promise).to.be.rejectedWith(HTTPError);
+      await expect(promise)
+        .to.be.eventually.rejectedWith(HTTPError)
+        .and.have.property('body', notFoundResponse[1]);
     });
 
-    it('rejects with HTTP error when 500 is returned from server', async () => {
+    it('rejects with correct HTTP error when 500 is returned from server', async () => {
       const promise = basicAuthRequest(internalServerRequestUrl, 'GET', authKey);
-      await expect(promise).to.be.rejectedWith(HTTPError);
+      await expect(promise)
+        .to.be.eventually.rejectedWith(HTTPError)
+        .and.have.property('body', JSON.stringify(internalServerResponse[1]));
     });
 
     it('rejects with ERROR when request fails with an error', async () => {
       const promise = basicAuthRequest(coreErrorRequestUrl, 'GET', authKey);
-      await expect(promise).to.be.rejectedWith(Error);
+      await expect(promise).to.be.eventually.rejectedWith(Error);
     });
   });
 });


### PR DESCRIPTION
Convert the body in http responses to String before passing to HTTPError constructor.

See issue: https://github.com/zeyneloz/onesignal-node/issues/58