### PR TITLE
📚 Document import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ npm install onesignal-node --save
 ``` js      
 const OneSignal = require('onesignal-node');    
 ```      
+OR
+``` js      
+import * as OneSignal from 'onesignal-node';  
+```
 
 ### Client Types:
 


### PR DESCRIPTION
### Description
- 📚 Document import syntax to avoid confusion during setup. As by default developers would try `import OneSignal from 'onesignal-node';` which will NOT throw, but simply be undefined.
- Example of confusion: https://github.com/zeyneloz/onesignal-node/issues/36