### PR TITLE
Add custom_data to CreateNotificationBody

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface CreateNotificationBody {
   template_id?: string;
   content_available?: boolean;
   mutable_content?: boolean;
+  custom_data?: KeyAnyObject;
 
   // Email content
   email_subject?: string;


### PR DESCRIPTION
Type modification is required to use "custom_data".

https://documentation.onesignal.com/docs/personalization#custom-data-api-only